### PR TITLE
fixed prod docker failing to run due to missing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 A Flask API server that handles enqueuing and dequeuing students from the office hours queue.
 
 # Quick Started
-1. You will first need to install all the development packages mainly use for 
+1. You will first need to install all the development packages mainly use for, it will allow you to run tools locally for the project.
+```bash
+pip install -r utils.txt
+```
 
 # Project structure
 [//]: # (TODO: Going to do a markdown of a file structure here so that you can see the project structure)
@@ -15,12 +18,10 @@ A Flask API server that handles enqueuing and dequeuing students from the office
 For this project please use the following python version:
 `"3.10", "3.11", "3.12"`
 
-
 Running the development server:
 ```bash
 docker compose up api-development --build
 ```
-
 
 # Pylint
 Project uses pylint to keep the code style organized
@@ -36,7 +37,6 @@ Using the Black formatter https://github.com/psf/black
 ```bash
 black $(git ls-files '*.py') 
 ```
-
 
 # Resource
 Good resources to look at:

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,12 +1,8 @@
 FROM python:latest
 LABEL authors="tomato"
 
-ARG API_MODE
-#This env is now re-used and set again within the container
-ENV API_MODE=$API_MODE
-
 WORKDIR app/
 
-COPY requirements_${API_MODE}.txt requirements.txt
+COPY requirements.txt .
 COPY gunicorn.conf.py gunicorn.conf.py
 RUN pip install -r requirements.txt

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 gunicorn
+requests

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -1,8 +1,0 @@
-Flask
-gunicorn
-
-
-# Development only packages:
-pylint
-black
-requests

--- a/api/utils.txt
+++ b/api/utils.txt
@@ -1,0 +1,2 @@
+pylint
+black

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,21 +2,19 @@ services:
   api-development:
     build:
       context: ./api/
-      args:
-        API_MODE: "dev"
+    environment:
+      API_MODE: "dev"
     volumes:
       - ./api:/app/api
     ports:
       - "8000:8000"
     command: flask --app api.server:app run --debug --host=0.0.0.0 --port=8000
 
-
   api-production:
     extends:
       service: api-development
-    build:
-      args:
+    environment:
         API_MODE: "prod"
     ports:
       - "8000:8000"
-    command: gunicorn 'api.server:create_app()' # this probably doesn't work
+    command: gunicorn 'api.server:create_app()'


### PR DESCRIPTION
- Updated Readme to fix the new requirement txt
- Changed `requirements_dev.txt` to `utils.txt` so users can install them locally on their machines for tools like pylint and black
- Adjusted docker compose to pass in `API_MODE` as environment variables and not docker build args

Test:
- prod and dev runs well locally within container